### PR TITLE
Configurable API URL, Optional Payload Inclusions, & Cross-platform support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-API_DOMAIN=http://localhost:8081
+API_DOMAIN=http://localhost:8080
 
 MONGO_CONNECTION_STRING=mongodb://root:example@localhost:27017/?retryWrites=true&w=majority
 MONGO_DATABASE=local

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
-MONGO_DOMAIN=foo
-MONGO_DATABASE=bar
-MONGO_PASSWORD=fiz
-MONGO_USERNAME=baz
+API_DOMAIN=http://localhost:8081
+
+MONGO_CONNECTION_STRING=mongodb://root:example@localhost:27017/?retryWrites=true&w=majority
+MONGO_DATABASE=local
+MONGO_DOMAIN=localhost
+MONGO_PASSWORD=example
+MONGO_USERNAME=root
 
 NEO4J_URL=foo
 NEO4J_USERNAME=bar

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,8 @@
       "internalConsoleOptions": "neverOpen",
       "port": 9229,
       "cwd": "${workspaceFolder}",
-      "envFile": "${workspaceFolder}/.env"
+      "envFile": "${workspaceFolder}/.env",
+      "preLaunchTask": "build"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "linux": {
+        "runtimeArgs": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/.bin/jest",
+          "--runInBand"
+        ]
+      },
+      "windows": {
+        "runtimeArgs": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/jest/bin/jest.js",
+          "--runInBand"
+        ]
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229,
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,8 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "port": 9229,
-      "cwd": "${workspaceFolder}"
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": ["$tsc", "$eslint-stylish"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "build",
       "type": "npm",
       "script": "build",
       "problemMatcher": ["$tsc", "$eslint-stylish"],

--- a/README.md
+++ b/README.md
@@ -10,17 +10,19 @@
 [![codeclimate-badge][]][codeclimate-link]
 [![snyk-badge][]][snyk-link]
 
-> The XYO Foundation provides this source code available in our efforts to advance the understanding of the XYO Procotol and its possible uses.
+> The XYO Foundation provides this source code available in our efforts to advance the understanding of the XYO Protocol and its possible uses.
 > We continue to maintain this software in the interest of developer education.
 > Usage of this source code is not intended for production.
 
 ## Table of Contents
 
--   [Title](#sdk-xyo-client-js)
--   [Description](#description)
--   [Maintainers](#maintainers)
--   [License](#license)
--   [Credits](#credits)
+- [sdk-xyo-client-js](#sdk-xyo-client-js)
+  - [Table of Contents](#table-of-contents)
+  - [Description](#description)
+  - [Install](#install)
+  - [Maintainers](#maintainers)
+  - [License](#license)
+  - [Credits](#credits)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@
 > Usage of this source code is not intended for production.
 
 ## Table of Contents
-
-- [sdk-xyo-client-js](#sdk-xyo-client-js)
-  - [Table of Contents](#table-of-contents)
-  - [Description](#description)
-  - [Install](#install)
-  - [Maintainers](#maintainers)
-  - [License](#license)
-  - [Credits](#credits)
+-   [Title](#sdk-xyo-client-js)
+-   [Table of Contents](#table-of-contents)
+-   [Description](#description)
+-   [Install](#install)
+-   [Maintainers](#maintainers)
+-   [License](#license)
+-   [Credits](#credits)
 
 ## Description
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,7 @@ const generateJestConfig = ({ esModules }) => {
       '^(\\.{1,2}/.*)\\.js$': '$1',
     },
     preset: 'ts-jest/presets/default-esm',
+    setupFiles: ['dotenv/config'],
     testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
     transform: {
       [`(${esModuleslist}).+\\.js$`]: 'babel-jest',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "npm-package-json-lint": "^5.4.2",
     "npm-package-json-lint-config-default": "^3.0.0",
     "prettier": "^2.5.1",
+    "rimraf": "^3.0.2",
     "rollbar": "^2.24.0",
     "rollup": "^2.63.0",
     "ts-jest": "^27.1.2",
@@ -88,7 +89,7 @@
     "url": "https://github.com/XYOracleNetwork/sdk-xyo-client-js.git"
   },
   "scripts": {
-    "compile": "rm -r -f dist && yarn compile-rollup && yarn compile-tsc",
+    "compile": "rimraf dist && yarn compile-rollup && yarn compile-tsc",
     "compile-rollup": "rollup -c",
     "compile-tsc": "tsc -p tsconfig.json",
     "lint-pkg": "npmPkgJsonLint .",

--- a/src/ArchivistApi/ArchivistApi.spec.ts
+++ b/src/ArchivistApi/ArchivistApi.spec.ts
@@ -2,57 +2,75 @@ import { AxiosError } from 'axios'
 
 import { XyoAddress } from '../Address'
 import { XyoBoundWitnessBuilder } from '../BoundWitness'
-import { XyoPayload } from '../models'
+import { XyoBoundWitness, XyoPayload } from '../models'
 import { XyoArchivistApi } from './ArchivistApi'
 import { XyoArchivistApiConfig } from './ArchivistApiConfig'
 
-test('checking happy path', async () => {
-  const payload: XyoPayload = {
-    number_field: 1,
-    object_field: {
-      number_value: 2,
-      string_value: 'yo',
-    },
-    schema: 'network.xyo.test',
-    string_field: 'there',
-    timestamp: 1618603439107,
-  }
+const payload: XyoPayload = {
+  number_field: 1,
+  object_field: {
+    number_value: 2,
+    string_value: 'yo',
+  },
+  schema: 'network.xyo.test',
+  string_field: 'there',
+  timestamp: 1618603439107,
+}
 
-  const config: XyoArchivistApiConfig = {
-    apiDomain: process.env.API_DOMAIN || 'https://api.archivist.xyo.network',
-    archive: 'test',
-  }
+const config: XyoArchivistApiConfig = {
+  apiDomain: process.env.API_DOMAIN || 'https://api.archivist.xyo.network',
+  archive: 'test',
+}
 
-  const address = XyoAddress.random()
+describe('XyoArchivistApi', () => {
+  describe('get', () => {
+    it('returns a new XyoArchivistApi', () => {
+      const api = XyoArchivistApi.get(config)
+      expect(api).toBeDefined()
+    })
+    describe('with no token', () => {
+      it('is not authenticated', () => {
+        const api = XyoArchivistApi.get(config)
+        expect(api.authenticated).toEqual(false)
+      })
+    })
+  })
+  describe('postBoundWitness', () => {
+    it('posts a single bound witness', async () => {
+      const builder = new XyoBoundWitnessBuilder({ inlinePayloads: true })
+        .witness(XyoAddress.random(), null)
+        .payload('network.xyo.test', payload)
+      const api = XyoArchivistApi.get(config)
+      const boundWitness: XyoBoundWitness = builder.build()
 
-  let builder = new XyoBoundWitnessBuilder()
-  expect(builder).toBeDefined()
-  builder = builder.witness(address, null)
-  expect(builder).toBeDefined()
-
-  builder = builder.payload('network.xyo.test', payload)
-  expect(builder).toBeDefined()
-
-  const json = builder.build()
-  expect(json).toBeDefined()
-
-  const api = XyoArchivistApi.get(config)
-  expect(api).toBeDefined()
-  expect(api.authenticated).toEqual(false)
-  try {
-    const postBoundWitnessResult = await api.postBoundWitness(json)
-    expect(postBoundWitnessResult.boundWitnesses).toEqual(1)
-  } catch (ex) {
-    const error = ex as AxiosError
-    console.log(JSON.stringify(error.response?.data, null, 2))
-    throw ex
-  }
-  try {
-    const postBoundWitnessesResult = await api.postBoundWitnesses([json, json])
-    expect(postBoundWitnessesResult.boundWitnesses).toEqual(2)
-  } catch (ex) {
-    const error = ex as AxiosError
-    console.log(JSON.stringify(error.response?.data, null, 2))
-    throw ex
-  }
-}, 40000)
+      try {
+        const postBoundWitnessResult = await api.postBoundWitness(boundWitness)
+        expect(postBoundWitnessResult.boundWitnesses).toEqual(1)
+        expect(postBoundWitnessResult.payloads).toEqual(1)
+      } catch (ex) {
+        const error = ex as AxiosError
+        console.log(JSON.stringify(error.response?.data, null, 2))
+        throw ex
+      }
+    }, 40000)
+  })
+  describe('postBoundWitnesses', () => {
+    it('posts multiple bound witnesses', async () => {
+      const builder = new XyoBoundWitnessBuilder({ inlinePayloads: true })
+        .witness(XyoAddress.random(), null)
+        .payload('network.xyo.test', payload)
+      const api = XyoArchivistApi.get(config)
+      const json = builder.build()
+      const boundWitnesses: XyoBoundWitness[] = [json, json]
+      try {
+        const postBoundWitnessesResult = await api.postBoundWitnesses(boundWitnesses)
+        expect(postBoundWitnessesResult.boundWitnesses).toEqual(2)
+        expect(postBoundWitnessesResult.payloads).toEqual(2)
+      } catch (ex) {
+        const error = ex as AxiosError
+        console.log(JSON.stringify(error.response?.data, null, 2))
+        throw ex
+      }
+    }, 40000)
+  })
+})

--- a/src/ArchivistApi/ArchivistApi.spec.ts
+++ b/src/ArchivistApi/ArchivistApi.spec.ts
@@ -19,8 +19,7 @@ test('checking happy path', async () => {
   }
 
   const config: XyoArchivistApiConfig = {
-    apiDomain: 'https://api.archivist.xyo.network',
-    //apiDomain: 'http://localhost:80',
+    apiDomain: process.env.API_DOMAIN || 'https://api.archivist.xyo.network',
     archive: 'test',
   }
 

--- a/src/ArchivistApi/ArchivistApi.spec.ts
+++ b/src/ArchivistApi/ArchivistApi.spec.ts
@@ -2,28 +2,16 @@ import { AxiosError } from 'axios'
 
 import { XyoAddress } from '../Address'
 import { XyoBoundWitnessBuilder } from '../BoundWitness'
-import { XyoBoundWitness, XyoPayload } from '../models'
+import { XyoBoundWitness } from '../models'
+import { testPayload, testSchema } from '../Test'
 import { XyoArchivistApi } from './ArchivistApi'
 import { XyoArchivistApiConfig } from './ArchivistApiConfig'
 
-const schema = 'network.xyo.test'
-const payload: XyoPayload = {
-  number_field: 1,
-  object_field: {
-    number_value: 2,
-    string_value: 'yo',
-  },
-  schema,
-  string_field: 'there',
-  timestamp: 1618603439107,
-}
-
+const timeout = 20000
 const config: XyoArchivistApiConfig = {
   apiDomain: process.env.API_DOMAIN || 'https://api.archivist.xyo.network',
   archive: 'test',
 }
-
-const timeout = 20000
 
 describe('XyoArchivistApi', () => {
   describe('get', () => {
@@ -44,7 +32,7 @@ describe('XyoArchivistApi', () => {
       async (inlinePayloads) => {
         const builder = new XyoBoundWitnessBuilder({ inlinePayloads })
           .witness(XyoAddress.random(), null)
-          .payload(schema, payload)
+          .payload(testSchema, testPayload)
         const api = XyoArchivistApi.get(config)
         const boundWitness: XyoBoundWitness = builder.build()
 
@@ -71,7 +59,7 @@ describe('XyoArchivistApi', () => {
       async (inlinePayloads) => {
         const builder = new XyoBoundWitnessBuilder({ inlinePayloads })
           .witness(XyoAddress.random(), null)
-          .payload(schema, payload)
+          .payload(testSchema, testPayload)
         const api = XyoArchivistApi.get(config)
         const json = builder.build()
         const boundWitnesses: XyoBoundWitness[] = [json, json]

--- a/src/ArchivistApi/ArchivistApi.ts
+++ b/src/ArchivistApi/ArchivistApi.ts
@@ -20,7 +20,7 @@ class XyoArchivistApi {
 
   public async postBoundWitnesses(boundWitnesses: XyoBoundWitness[]) {
     return (
-      await axios['post']<{ boundWitnesses?: number; payloads?: number }>(
+      await axios['post']<{ boundWitnesses: number; payloads: number }>(
         `${this.config.apiDomain}/archive/${this.config.archive}/block`,
         { boundWitnesses },
         {

--- a/src/ArchivistMongoSdk/BoundWitnessSdk.spec.ts
+++ b/src/ArchivistMongoSdk/BoundWitnessSdk.spec.ts
@@ -8,6 +8,7 @@ const getMongoSdk = (archive: string) => {
   return new XyoArchivistBoundWitnessMongoSdk(
     {
       collection: 'bound_witnesses',
+      dbConnectionString: process.env.MONGO_CONNECTION_STRING,
       dbDomain: assertEx(process.env.MONGO_DOMAIN, 'Missing Mongo Domain'),
       dbName: assertEx(process.env.MONGO_DATABASE, 'Missing Mongo Database'),
       dbPassword: assertEx(process.env.MONGO_PASSWORD, 'Missing Mongo Password'),

--- a/src/ArchivistMongoSdk/PayloadSdk.spec.ts
+++ b/src/ArchivistMongoSdk/PayloadSdk.spec.ts
@@ -8,6 +8,7 @@ const getMongoSdk = (archive: string) => {
   return new XyoArchivistPayloadMongoSdk(
     {
       collection: 'payloads',
+      dbConnectionString: process.env.MONGO_CONNECTION_STRING,
       dbDomain: assertEx(process.env.MONGO_DOMAIN, 'Missing Mongo Domain'),
       dbName: assertEx(process.env.MONGO_DATABASE, 'Missing Mongo Database'),
       dbPassword: assertEx(process.env.MONGO_PASSWORD, 'Missing Mongo Password'),

--- a/src/BoundWitness/Builder/Builder.spec.ts
+++ b/src/BoundWitness/Builder/Builder.spec.ts
@@ -4,55 +4,50 @@ import { XyoAddress } from '../../Address'
 import { XyoPayload } from '../../models'
 import { XyoBoundWitnessBuilder } from './Builder'
 
-test('checking happy path', () => {
-  const payload1: XyoPayload = {
-    schema: 'network.xyo.test',
-    number_field: 1,
-    object_field: {
-      number_value: 2,
-      string_value: 'yo',
-    },
-    string_field: 'there',
-    timestamp: 1618603439107,
-  }
-  const payload2: XyoPayload = {
-    schema: 'network.xyo.test',
-    number_field: 1,
-    timestamp: 1618603439107,
-    object_field: {
-      string_value: 'yo',
-      number_value: 2,
-    },
-    string_field: 'there',
-  }
+const schema = 'network.xyo.test'
+const payload1: XyoPayload = {
+  number_field: 1,
+  object_field: {
+    number_value: 2,
+    string_value: 'yo',
+  },
+  schema,
+  string_field: 'there',
+  timestamp: 1618603439107,
+}
+const payload2: XyoPayload = {
+  timestamp: 1618603439107,
+  string_field: 'there',
+  schema,
+  object_field: {
+    string_value: 'yo',
+    number_value: 2,
+  },
+  number_field: 1,
+}
+const payloads = [payload1, payload2]
+const payloadHash = 'c915c56dd93b5e0db509d1a63ca540cfb211e11f03039b05e19712267bb8b6db'
+const jsonHash = '98e1a3a3483ae211e702ee9952f9cae335e571ab7c1de708edb97eacdd960ba1'
 
-  const payload1Hash = XyoBoundWitnessBuilder.hash(payload1)
+describe('XyoBoundWitnessBuilder', () => {
+  describe('hash', () => {
+    it.each(payloads)('consistently hashes equivalent payload independent of the order of the keys', (payload) => {
+      const hash = XyoBoundWitnessBuilder.hash(payload)
+      expect(hash).toEqual(payloadHash)
+    })
+  })
+  describe('build', () => {
+    it.each(payloads)('consistently hashes equivalent payloads independent of the order of the keys', (payload) => {
+      let builder = new XyoBoundWitnessBuilder()
+      expect(builder).toBeDefined()
+      builder = builder.witness(XyoAddress.fromPhrase('test'), null)
+      expect(builder).toBeDefined()
 
-  expect(payload1Hash).toEqual('c915c56dd93b5e0db509d1a63ca540cfb211e11f03039b05e19712267bb8b6db')
-
-  const knownHash = '98e1a3a3483ae211e702ee9952f9cae335e571ab7c1de708edb97eacdd960ba1'
-
-  const address = XyoAddress.fromPhrase('test')
-
-  let builder1 = new XyoBoundWitnessBuilder()
-  expect(builder1).toBeDefined()
-  builder1 = builder1.witness(address, null)
-  expect(builder1).toBeDefined()
-
-  builder1 = builder1.payload('network.xyo.test', payload1)
-  expect(builder1).toBeDefined()
-  const json1 = builder1.build()
-  expect(json1).toBeDefined()
-  expect(json1._hash).toEqual(knownHash)
-
-  let builder2 = new XyoBoundWitnessBuilder()
-  expect(builder2).toBeDefined()
-  builder2 = builder2.witness(address, null)
-  expect(builder2).toBeDefined()
-
-  builder2 = builder2.payload('network.xyo.test', payload2)
-  expect(builder2).toBeDefined()
-  const json2 = builder2.build()
-  expect(json2).toBeDefined()
-  expect(json2._hash).toEqual(knownHash)
+      builder = builder.payload(schema, payload)
+      expect(builder).toBeDefined()
+      const json1 = builder.build()
+      expect(json1).toBeDefined()
+      expect(json1._hash).toEqual(jsonHash)
+    })
+  })
 })

--- a/src/BoundWitness/Builder/Builder.spec.ts
+++ b/src/BoundWitness/Builder/Builder.spec.ts
@@ -28,6 +28,7 @@ const payload2: XyoPayload = {
 const payloads = [payload1, payload2]
 const payloadHash = 'c915c56dd93b5e0db509d1a63ca540cfb211e11f03039b05e19712267bb8b6db'
 const jsonHash = '98e1a3a3483ae211e702ee9952f9cae335e571ab7c1de708edb97eacdd960ba1'
+const address = XyoAddress.fromPhrase('test')
 
 describe('XyoBoundWitnessBuilder', () => {
   describe('hash', () => {
@@ -37,17 +38,44 @@ describe('XyoBoundWitnessBuilder', () => {
     })
   })
   describe('build', () => {
-    it.each(payloads)('consistently hashes equivalent payloads independent of the order of the keys', (payload) => {
-      let builder = new XyoBoundWitnessBuilder()
-      expect(builder).toBeDefined()
-      builder = builder.witness(XyoAddress.fromPhrase('test'), null)
-      expect(builder).toBeDefined()
+    describe('_hash', () => {
+      it.each(payloads)('consistently hashes equivalent payloads independent of the order of the keys', (payload) => {
+        let builder = new XyoBoundWitnessBuilder()
+        expect(builder).toBeDefined()
+        builder = builder.witness(address, null)
+        expect(builder).toBeDefined()
+        builder = builder.payload(schema, payload)
+        expect(builder).toBeDefined()
 
-      builder = builder.payload(schema, payload)
-      expect(builder).toBeDefined()
-      const json1 = builder.build()
-      expect(json1).toBeDefined()
-      expect(json1._hash).toEqual(jsonHash)
+        const actual = builder.build()
+
+        expect(actual).toBeDefined()
+        expect(actual._hash).toEqual(jsonHash)
+      })
+    })
+    describe('with inlinePayloads true', () => {
+      it('contains the _payloads field', () => {
+        const builder = new XyoBoundWitnessBuilder({ inlinePayloads: true })
+          .witness(address, null)
+          .payload(schema, payload1)
+
+        const actual = builder.build()
+
+        expect(actual).toBeDefined()
+        expect(actual._payloads).toBeDefined()
+      })
+    })
+    describe('with inlinePayloads false', () => {
+      it('omits the _payloads field', () => {
+        const builder = new XyoBoundWitnessBuilder({ inlinePayloads: false })
+          .witness(address, null)
+          .payload(schema, payload1)
+
+        const actual = builder.build()
+
+        expect(actual).toBeDefined()
+        expect(actual._payloads).toBeUndefined()
+      })
     })
   })
 })

--- a/src/Payload/Validator/Validator.spec.ts
+++ b/src/Payload/Validator/Validator.spec.ts
@@ -2,7 +2,7 @@ import { dumpErrors } from '../../dumpErrors'
 import { XyoPayload } from '../../models'
 import { XyoPayloadValidator } from './Validator'
 
-const testPayloadNoSchmea: XyoPayload = {
+const testPayloadNoSchema: XyoPayload = {
   _hash: '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
   _timestamp: 1609459255555,
 } as XyoPayload
@@ -28,7 +28,7 @@ const testPayloadValid: XyoPayload = {
 }
 
 test('all [missing schema]', () => {
-  const validator = new XyoPayloadValidator(testPayloadNoSchmea)
+  const validator = new XyoPayloadValidator(testPayloadNoSchema)
   const errors = validator.all()
   dumpErrors(errors)
   expect(errors.length).toBe(1)

--- a/src/Test/testPayload.ts
+++ b/src/Test/testPayload.ts
@@ -1,5 +1,6 @@
 import { XyoPayload } from '../models'
 
+const testSchema = 'network.xyo.test'
 const testPayload: XyoPayload = {
   _archive: 'test',
   _hash: '20e14207f952a09f767ff614a648546c037fe524ace0bfe55db31f818aff1f1c',
@@ -9,8 +10,8 @@ const testPayload: XyoPayload = {
     numberField: 1,
     stringField: 'stringValue',
   },
-  schema: 'network.xyo.test',
+  schema: testSchema,
   stringField: 'stringValue',
 }
 
-export { testPayload }
+export { testPayload, testSchema }


### PR DESCRIPTION
Add support for:
- Option to include payload(s) when posting to Archivist API
- Windows
- Jest Test Debugging through VSCode
- Archivist API testing locally via ENV VARs to control targeting of tests to local dev vs cloud