### PR TITLE
Remove underscore fields

### DIFF
--- a/packages/sdk/boundwitness/src/Wrapper/Wrapper.ts
+++ b/packages/sdk/boundwitness/src/Wrapper/Wrapper.ts
@@ -4,19 +4,7 @@ import { UAParser } from 'ua-parser-js'
 
 import { XyoBoundWitness, XyoBoundWitnessWithMeta } from '../models'
 
-const scrubbedFields = [
-  '_archive',
-  '_client',
-  '_hash',
-  '_signatures',
-  '_timestamp',
-  '_user_agent',
-  'addresses',
-  'payload_schemas',
-  'previous_hashes',
-  'payload_hashes',
-  'schema',
-]
+const scrubbedFields = ['_signatures', 'addresses', 'payload_schemas', 'previous_hashes', 'payload_hashes', 'schema']
 
 export class XyoBoundWitnessWrapper<T extends XyoBoundWitness> extends XyoHasher<T> {
   public readonly bw: T


### PR DESCRIPTION
Leave `_signatures` field as it's a reserved keyword that can't be part of the non-underscored properties as it'll change the hash.