### PR TITLE
huri token support

### DIFF
--- a/packages/modules/packages/diviner/src/Payload/Huri/Diviner.ts
+++ b/packages/modules/packages/diviner/src/Payload/Huri/Diviner.ts
@@ -26,7 +26,9 @@ export class HuriPayloadDiviner extends AbstractPayloadDiviner<XyoHuriPayloadDiv
       payloads?.filter((payload): payload is XyoHuriPayload => payload?.schema === XyoHuriSchema),
       `no huri payloads provided: ${JSON.stringify(payloads, null, 2)}`,
     )
-    const huriList = huriPayloads.map((huriPayload) => huriPayload.huri.map((huri) => new Huri(huri, { token: huriPayload.token }))).flat()
+    const huriList = huriPayloads
+      .map((huriPayload, index) => huriPayload.huri.map((huri) => new Huri(huri, { token: huriPayload.tokens?.[index] })))
+      .flat()
 
     const settled = await Promise.allSettled(huriList.map((huri) => huri.fetch()))
     return compact(settled.filter(fulfilled).map((settle) => settle.value))

--- a/packages/modules/packages/diviner/src/Payload/Huri/Diviner.ts
+++ b/packages/modules/packages/diviner/src/Payload/Huri/Diviner.ts
@@ -26,7 +26,7 @@ export class HuriPayloadDiviner extends AbstractPayloadDiviner<XyoHuriPayloadDiv
       payloads?.filter((payload): payload is XyoHuriPayload => payload?.schema === XyoHuriSchema),
       `no huri payloads provided: ${JSON.stringify(payloads, null, 2)}`,
     )
-    const huriList = huriPayloads.map((huriPayload) => huriPayload.huri.map((huri) => new Huri(huri))).flat()
+    const huriList = huriPayloads.map((huriPayload) => huriPayload.huri.map((huri) => new Huri(huri, { token: huriPayload.token }))).flat()
 
     const settled = await Promise.allSettled(huriList.map((huri) => huri.fetch()))
     return compact(settled.filter(fulfilled).map((settle) => settle.value))

--- a/packages/modules/packages/diviner/src/Payload/XyoHuriPayload.ts
+++ b/packages/modules/packages/diviner/src/Payload/XyoHuriPayload.ts
@@ -6,4 +6,5 @@ export const XyoHuriSchema: XyoHuriSchema = 'network.xyo.huri'
 export type XyoHuriPayload = XyoPayload<{
   huri: string[]
   schema: 'network.xyo.huri'
+  token?: string
 }>

--- a/packages/modules/packages/diviner/src/Payload/XyoHuriPayload.ts
+++ b/packages/modules/packages/diviner/src/Payload/XyoHuriPayload.ts
@@ -6,5 +6,5 @@ export const XyoHuriSchema: XyoHuriSchema = 'network.xyo.huri'
 export type XyoHuriPayload = XyoPayload<{
   huri: string[]
   schema: 'network.xyo.huri'
-  token?: string
+  tokens?: string[]
 }>

--- a/packages/protocol/packages/payload/packages/huri/src/Huri.spec.ts
+++ b/packages/protocol/packages/payload/packages/huri/src/Huri.spec.ts
@@ -1,4 +1,5 @@
 import { delay } from '@xylabs/delay'
+import { axios } from '@xyo-network/axios'
 import { XyoPayload } from '@xyo-network/payload-model'
 
 import { Huri } from './Huri'
@@ -65,6 +66,19 @@ describe('Huri', () => {
       const huri = new Huri('https://beta.api.archivist.xyo.network/18f97b3e85f5bede65e7c0a85d74aee896de58ead8bc4b1b3d7300646c653057')
       const result = await huri.fetch()
       expect(result?.schema).toBe('network.xyo.schema')
+    })
+    it('Valid Huri with token', (done) => {
+      const token = 'abc123'
+      const huri = new Huri('https://beta.api.archivist.xyo.network/18f97b3e85f5bede65e7c0a85d74aee896de58ead8bc4b1b3d7300646c653057', { token })
+      expect(huri.token).toBe(token)
+      axios.interceptors.request.use((config) => {
+        const tokenValue = config.headers.get('Authorization')
+        expect(tokenValue).toBe(`Bearer ${token}`)
+        done()
+        return config
+      })
+      // ignore result since token is fake
+      huri.fetch().catch(() => undefined)
     })
     it('Invalid Huri', async () => {
       const huri = new Huri('https://beta.api.archivist.xyo.network/18f97b3e85f5bede65e7c0a85d74aee896de58ead8bc4b1b3d7300646c653bad')

--- a/packages/protocol/packages/payload/packages/huri/src/Huri.ts
+++ b/packages/protocol/packages/payload/packages/huri/src/Huri.ts
@@ -20,6 +20,7 @@ export type HuriFetchFunction = (huri: Huri) => Promise<XyoPayload | undefined>
 
 export interface HuriOptions {
   archivistUri?: string
+  token?: string
 }
 
 export interface FetchedPayload<T extends XyoPayload = XyoPayload> {
@@ -33,10 +34,11 @@ export class Huri<T extends XyoPayload = XyoPayload> {
   public hash: string
   public originalHref: string
   public protocol?: string
+  public token?: string
 
   private isHuri = true
 
-  constructor(huri: DataLike | Huri, { archivistUri }: HuriOptions = {}) {
+  constructor(huri: DataLike | Huri, { archivistUri, token }: HuriOptions = {}) {
     const huriString = Huri.isHuri(huri)?.href ?? typeof huri === 'string' ? (huri as string) : new AddressValue(huri as DataLike).hex
     this.originalHref = huriString
 
@@ -52,6 +54,8 @@ export class Huri<T extends XyoPayload = XyoPayload> {
       this.protocol = archivistUriParts[0]
       this.archivist = archivistUriParts[1]
     }
+
+    this.token = token
 
     this.validateParse()
   }
@@ -75,7 +79,8 @@ export class Huri<T extends XyoPayload = XyoPayload> {
   }
 
   static async fetch<T extends XyoPayload = XyoPayload>(huri: Huri): Promise<T | undefined> {
-    return (await axios.get<T>(huri.href)).data
+    const AuthHeader = huri.token ? { Authorization: `Bearer ${huri.token}` } : undefined
+    return (await axios.get<T>(huri.href, { headers: AuthHeader })).data
   }
 
   public static isHuri(value: unknown) {


### PR DESCRIPTION
A Huri doesn't include any security since its a more of a resource indicator.  This PR allows for the inclusion of tokens to pass along with the huri for resolution.

Changes:
* add an optional array of `tokens` to mirror the huri `string[]` in `XyoHuriPayload`
* Pass tokens as `Authorization` Header per huri requested.

Fixes: #632 